### PR TITLE
StreamsFromPaths now returns err object if a stream was not found

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,12 +83,18 @@ func (ds *DISTIL) RegisterDistillate(r *Registration) {
 		fmt.Println("Aborting. Cannot register a distillate with no Instance")
 		os.Exit(1)
 	}
+	inputs, err := ds.StreamsFromPaths(r.InputPaths)
+	if err != nil {
+		fmt.Println("WARN: Registration ignored.  One or more streams not found.\n")
+		return
+	}
+
 	h := handle{
 		d:   r.Instance,
 		reg: *r,
 	}
 	r.Instance.SetEngine(ds)
-	h.inputs = ds.StreamsFromPaths(h.reg.InputPaths)
+	h.inputs = inputs
 	h.outputs = ds.MakeOrGetByPaths(h.reg.OutputPaths, h.reg.OutputUnits)
 	ds.distillates = append(ds.distillates, &h)
 }

--- a/stream.go
+++ b/stream.go
@@ -2,8 +2,8 @@ package distil
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -130,17 +130,17 @@ func (ds *DISTIL) StreamFromPath(path string) *Stream {
 }
 
 // Obtain multiple streams based on paths
-func (ds *DISTIL) StreamsFromPaths(paths []string) []*Stream {
+func (ds *DISTIL) StreamsFromPaths(paths []string) ([]*Stream, error) {
 	//loop over StreamFromPath
 	var streams = make([]*Stream, len(paths))
 	for i, path := range paths {
 		streams[i] = ds.StreamFromPath(path)
 		if streams[i] == nil {
-			fmt.Printf("could not locate stream %q\n", path)
-			os.Exit(1)
+			fmt.Printf("WARN: could not locate stream (%s)\n", path)
+			return nil, errors.New(fmt.Sprintf("Stream not found (%s)", path))
 		}
 	}
-	return streams
+	return streams, nil
 }
 
 // This is the same as StreamFromPath, but if the path does not exist, it will

--- a/stream.go
+++ b/stream.go
@@ -137,7 +137,7 @@ func (ds *DISTIL) StreamsFromPaths(paths []string) ([]*Stream, error) {
 		streams[i] = ds.StreamFromPath(path)
 		if streams[i] == nil {
 			fmt.Printf("WARN: could not locate stream (%s)\n", path)
-			return nil, errors.New(fmt.Sprintf("Stream not found (%s)", path))
+			return nil, fmt.Errorf("Stream not found (%s)", path)
 		}
 	}
 	return streams, nil

--- a/stream.go
+++ b/stream.go
@@ -2,7 +2,6 @@ package distil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"


### PR DESCRIPTION
This modifies `StreamsFromPaths` to return an error object if any streams were not found by path.  Additionally, `main.go` was modified to cancel/ignore distiller registration if `StreamsFromPaths` returns an error.

*NOTE* I wasn't able to test this locally.